### PR TITLE
Updated Deno.setRaw to Deno.stdin.setRaw

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -289,8 +289,8 @@ export function beginListeningToKeyboard () {
 	}
 	isListening = true;
 	
-	Deno.setRaw( Deno.stdin.rid, true );
-	cleanupActions.push( () => Deno.setRaw( Deno.stdin.rid, false ) );
+	Deno.stdin.setRaw( Deno.stdin.rid, true );
+	cleanupActions.push( () => Deno.stdin.setRaw( Deno.stdin.rid, false ) );
 }
 
 export async function* keyboardInput () {


### PR DESCRIPTION
Deno.setRaw will throw an error as of 1.26.0. It is now accessed using Deno.stdin.setRaw()

https://github.com/denoland/deno/pull/15797
https://stackoverflow.com/questions/74104584/how-to-fix-an-error-in-a-deno-dependency

I used `Deno.setRaw = Deno.stdin.setRaw
` to hack it in my own code but figured you might want a quick PR to update it for future users.